### PR TITLE
Set requires-python version in pyproject.toml, fixes #5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">3.7,<3.11"
+
 [build-system]
 requires = [
     "setuptools>=42",


### PR DESCRIPTION
pyzmq `22.x` only works with python up to 3.10. For python 3.11 or above the pyzmq needs to be upgraded to `23.x`. [Here](https://github.com/zeromq/pyzmq/issues/1697) is the issue with a more lengthy description. Rather than updating pzmq right now, I've restricted the versions that covfee is compatible with. I've only tested this on ubuntu 22.04. So we might need to restrict the versions further on MacOS or Windows.